### PR TITLE
Add option for setting the default value when decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ An `inlineArrays` option to parse the following. This is common in Unreal Engine
 Previously, only the last `sServerAdmins` would be retained and the previous ones would be stripped. Now, when this option is passed, this is parsed into an array:
 `[12345, 54321, 09876]`
 
+### New `defaultValue` option
+An `defaultValue` option when decoding to use when encountering a key without a value.
+```ini
+    key=
+    secondkey
+```
+Previously both keys would contain the value `true`, now both keys would contain whatever this option is set to, or an empty string if this option is not set. This is a breaking change, and will decode some inputs differently.
+
 ## Usage
 
 Consider an ini-file `config.ini` that looks like this:

--- a/ini.js
+++ b/ini.js
@@ -73,6 +73,8 @@ function dotSplit(str){
 }
 
 function decode(str, opt = {}){
+	const defaultValue = typeof opt.defaultValue !== 'undefined' ? opt.defaultValue : '';
+
 	const out = {};
 	let ref = out;
 	let section = null;
@@ -90,7 +92,7 @@ function decode(str, opt = {}){
 			return;
 		}
 		let key = unsafe(match[2]);
-		let value = match[3] ? unsafe(match[3]) : true;
+		let value = match[3] ? unsafe(match[3]) : defaultValue;
 		switch(value){
 			case 'true':
 			case 'false':

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@nodecraft/css-loader",
+	"name": "@nodecraft/ini",
 	"version": "1.4.0",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nodecraft/ini",
-	"version": "1.4.0",
+	"version": "2.0.0",
 	"description": "An ini encoder/decoder for node",
 	"repository": {
 		"type": "git",

--- a/test/fixtures/foo.ini
+++ b/test/fixtures/foo.ini
@@ -31,6 +31,9 @@ br = warm
 
 eq = "eq=eq"
 
+; Test no value
+nv =
+
 ; a section
 [a]
 av = a val

--- a/test/fixtures/fooInlineArrays.ini
+++ b/test/fixtures/fooInlineArrays.ini
@@ -31,6 +31,9 @@ br = warm
 
 eq = "eq=eq"
 
+; Test no value
+nv =
+
 ; a section
 [a]
 av = a val

--- a/test/foo.js
+++ b/test/foo.js
@@ -25,7 +25,8 @@ const expectE = 'o=p' + eol
             + 'ar[]=three' + eol
             + 'ar[]=this is included' + eol
             + 'br=warm' + eol
-            + 'eq="eq=eq"' + eol + eol
+            + 'eq="eq=eq"' + eol
+            + 'nv=' + eol + eol
             + '[a]' + eol
             + 'av=a val' + eol
             + 'e={ o: p, a: '
@@ -58,7 +59,8 @@ const expectE = 'o=p' + eol
             + 'ar=three' + eol
             + 'ar=this is included' + eol
             + 'br=warm' + eol
-            + 'eq="eq=eq"' + eol + eol
+            + 'eq="eq=eq"' + eol
+            + 'nv=' + eol + eol
             + '[a]' + eol
             + 'av=a val' + eol
             + 'e={ o: p, a: '
@@ -91,6 +93,7 @@ const expectE = 'o=p' + eol
 		'ar': ['one', 'three', 'this is included'],
 		'br': 'warm',
 		'eq': 'eq=eq',
+		'nv': '',
 		a: {
 			av: 'a val',
 			e: '{ o: p, a: { av: a val, b: { c: { e: "this [value]" } } } }',
@@ -127,6 +130,7 @@ const expectE = 'o=p' + eol
 		'ar': ['one', 'three', 'this is included'],
 		'br': ['cold', 'warm'],
 		'eq': 'eq=eq',
+		'nv': '',
 		a: {
 			av: 'a val',
 			e: '{ o: p, a: { av: a val, b: { c: { e: "this [value]" } } } }',
@@ -229,8 +233,16 @@ test('array destructing', function(t){
 	t.end();
 });
 
-test('defaulting unset value to true', function(t){
+test('defaulting unset value to an empty string', function(t){
 	t.same(ini.decode('foo' + eol + 'bar=false' + eol), {
+		foo: '',
+		bar: false
+	});
+	t.end();
+});
+
+test('defaulting unset value to specified value', function(t){
+	t.same(ini.decode('foo' + eol + 'bar=false' + eol, {defaultValue: true}), {
 		foo: true,
 		bar: false
 	});


### PR DESCRIPTION
Currently an ini file that contains a key without a value will be decoded with that key containing `true`. This PR changes this default value to an empty string, in addition to adding an option to set the default value to preserve the previous behavior if desired.